### PR TITLE
Adding links to API and feed

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -6,11 +6,11 @@ layout: layouts/base.njk
 
 <div class="center">
   <h3>API</h3>
-  <p>The API endpoint is at <code>/api/</code>.</p>
+  <p>The API endpoint is at [<code>/api/</code>](/api/).</p>
   <pre><code>$ curl https://www.browsers.fyi/api/</code></pre>
 </div>
 
 <div class="center">
   <h3>RSS</h3>
-  <p>And because RSS is obviously not dead, a feed that includes releases notes is available at <code>/feed/</code>.</p>
+  <p>And because RSS is obviously not dead, a feed that includes releases notes is available at [<code>/feed/</code>](/feed/).</p>
 </div>


### PR DESCRIPTION
When on the site, I tried to click on "/feed/", because it says "is available at" so it made sense it was a link.

Of course, you may have a good reason for these not to be links… 😅